### PR TITLE
Add ability to pass attributes onto Footer links

### DIFF
--- a/src/modules/Footer/__snapshots__/index.test.js.snap
+++ b/src/modules/Footer/__snapshots__/index.test.js.snap
@@ -7,7 +7,7 @@ exports[`Footer renders when everything passed in 1`] = `
     target="_blank"
     type="secondary"
   >
-    Help & Faq
+    Help & FAQs
   </Styled(Link)>
   <Styled(div)>
     <Styled(ul)>
@@ -53,7 +53,7 @@ exports[`Footer renders with no items 1`] = `
     target="_blank"
     type="secondary"
   >
-    Help & Faq
+    Help & FAQs
   </Styled(Link)>
   <Styled(div)>
     <Styled(ul) />
@@ -71,7 +71,7 @@ exports[`Footer renders without copyright 1`] = `
     target="_blank"
     type="secondary"
   >
-    Help & Faq
+    Help & FAQs
   </Styled(Link)>
   <Styled(div)>
     <Styled(ul)>

--- a/src/modules/Footer/__snapshots__/index.test.js.snap
+++ b/src/modules/Footer/__snapshots__/index.test.js.snap
@@ -15,27 +15,27 @@ exports[`Footer renders when everything passed in 1`] = `
         key="1"
       >
         <Styled(a)
-          href="https://cookie.fr"
+          href="https://google.com"
         >
-          cookie
+          Terms & Conditions
         </Styled(a)>
       </Styled(li)>
       <Styled(li)
         key="2"
       >
         <Styled(a)
-          href="https://tm.fr"
+          href="https://google.com"
         >
-          Terms & Conditions
+          Privacy Policy
         </Styled(a)>
       </Styled(li)>
       <Styled(li)
         key="3"
       >
         <Styled(a)
-          href="https://policy.fr"
+          href="https://google.com"
         >
-          privacy policy
+          Cookie Policy
         </Styled(a)>
       </Styled(li)>
     </Styled(ul)>
@@ -79,27 +79,27 @@ exports[`Footer renders without copyright 1`] = `
         key="1"
       >
         <Styled(a)
-          href="https://cookie.fr"
+          href="https://google.com"
         >
-          cookie
+          Terms & Conditions
         </Styled(a)>
       </Styled(li)>
       <Styled(li)
         key="2"
       >
         <Styled(a)
-          href="https://tm.fr"
+          href="https://google.com"
         >
-          Terms & Conditions
+          Privacy Policy
         </Styled(a)>
       </Styled(li)>
       <Styled(li)
         key="3"
       >
         <Styled(a)
-          href="https://policy.fr"
+          href="https://google.com"
         >
-          privacy policy
+          Cookie Policy
         </Styled(a)>
       </Styled(li)>
     </Styled(ul)>

--- a/src/modules/Footer/index.js
+++ b/src/modules/Footer/index.js
@@ -79,14 +79,14 @@ const StyledCopyright = styled('div')`
 
 const Footer = ({ faq, items, copyright }) => (
   <StyledWrapper>
-    <StyledButton type="secondary" href={faq.link} target="_blank">
+    <StyledButton {...faq.linkProps} type="secondary" target="_blank">
       {faq.label}
     </StyledButton>
     <StyledColumn>
       <StyledItems>
         {items.map(item => (
           <StyledItem key={item.id}>
-            <StyledLink href={item.link}>{item.label}</StyledLink>
+            <StyledLink {...item.linkProps}>{item.label}</StyledLink>
           </StyledItem>
         ))}
       </StyledItems>
@@ -103,14 +103,18 @@ Footer.defaultProps = {
 Footer.propTypes = {
   copyright: PropTypes.string,
   faq: PropTypes.shape({
-    link: PropTypes.string,
     label: PropTypes.string,
+    linkProps: PropTypes.shape({
+      href: PropTypes.string.isRequired,
+    }).isRequired,
   }).isRequired,
   items: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.number,
-      link: PropTypes.string,
       label: PropTypes.string,
+      linkProps: PropTypes.shape({
+        href: PropTypes.string.isRequired,
+      }).isRequired,
     })
   ),
 };

--- a/src/modules/Footer/index.stories.js
+++ b/src/modules/Footer/index.stories.js
@@ -7,23 +7,31 @@ import { Footer } from '../..';
 const footerStories = storiesOf('Footer', module);
 const faq = {
   label: 'Help & Faq',
-  link: 'https://google.fr',
+  linkProps: {
+    href: 'https://google.fr',
+  },
 };
 const items = [
   {
     id: 1,
-    label: 'cookie',
-    link: 'https://cookie.fr',
+    label: 'Terms & Conditions',
+    linkProps: {
+      href: 'https://google.com',
+    },
   },
   {
     id: 2,
-    label: 'Terms & Conditions',
-    link: 'https://tm.fr',
+    label: 'Privacy Policy',
+    linkProps: {
+      href: 'https://google.com',
+    },
   },
   {
     id: 3,
-    label: 'privacy policy',
-    link: 'https://policy.fr',
+    label: 'Cookie Policy',
+    linkProps: {
+      href: 'https://google.com',
+    },
   },
 ];
 

--- a/src/modules/Footer/index.test.js
+++ b/src/modules/Footer/index.test.js
@@ -4,23 +4,31 @@ import Footer from '.';
 
 const faq = {
   label: 'Help & Faq',
-  link: 'https://google.fr',
+  linkProps: {
+    href: 'https://google.fr',
+  },
 };
 const items = [
   {
     id: 1,
-    label: 'cookie',
-    link: 'https://cookie.fr',
+    label: 'Terms & Conditions',
+    linkProps: {
+      href: 'https://google.com',
+    },
   },
   {
     id: 2,
-    label: 'Terms & Conditions',
-    link: 'https://tm.fr',
+    label: 'Privacy Policy',
+    linkProps: {
+      href: 'https://google.com',
+    },
   },
   {
     id: 3,
-    label: 'privacy policy',
-    link: 'https://policy.fr',
+    label: 'Cookie Policy',
+    linkProps: {
+      href: 'https://google.com',
+    },
   },
 ];
 

--- a/src/modules/Footer/index.test.js
+++ b/src/modules/Footer/index.test.js
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 import Footer from '.';
 
 const faq = {
-  label: 'Help & Faq',
+  label: 'Help & FAQs',
   linkProps: {
     href: 'https://google.fr',
   },
@@ -43,5 +43,38 @@ describe('Footer', () => {
 
   it('renders with no items', () => {
     expect(shallow(<Footer faq={faq} copyright="copyright" />)).toMatchSnapshot();
+  });
+
+  it('should allow extra attibutes to be passed to the faq link (eg for analytics to hook into)', () => {
+    const faqWithExtraAttibute = {
+      label: 'Help & FAQs',
+      linkProps: {
+        href: 'https://google.fr',
+        'data-adobe-analytics': 'an-adobe-analytics-value',
+      },
+    };
+
+    const component = shallow(<Footer faq={faqWithExtraAttibute} />);
+    const helpButton = component.find({ children: 'Help & FAQs' });
+
+    expect(helpButton.props()).toHaveProperty('data-adobe-analytics', 'an-adobe-analytics-value');
+  });
+
+  it('should allow extra attibutes to be passed to an item link (eg for analytics to hook into)', () => {
+    const itemWithExtraAttibute = [
+      {
+        id: 1,
+        label: 'Terms & Conditions',
+        linkProps: {
+          href: 'https://google.fr',
+          'data-adobe-analytics': 'an-adobe-analytics-value',
+        },
+      },
+    ];
+
+    const component = shallow(<Footer faq={faq} items={itemWithExtraAttibute} />);
+    const itemLink = component.find({ children: 'Terms & Conditions' });
+
+    expect(itemLink.props()).toHaveProperty('data-adobe-analytics', 'an-adobe-analytics-value');
   });
 });


### PR DESCRIPTION
Change Footer so the consuming application can pass props onto links for analytics purposes.

We need to pass attributes onto the footer links, but this should be defined in consuming applications, and not in the toolkit.