### PR TITLE
Add props to footer component

### DIFF
--- a/src/modules/Footer/index.js
+++ b/src/modules/Footer/index.js
@@ -77,8 +77,8 @@ const StyledCopyright = styled('div')`
   color: ${colors.manatee};
 `;
 
-const Footer = ({ faq, items, copyright }) => (
-  <StyledWrapper>
+const Footer = ({ faq, items, copyright, ...props }) => (
+  <StyledWrapper {...props}>
     <StyledButton {...faq.linkProps} type="secondary" target="_blank">
       {faq.label}
     </StyledButton>

--- a/src/modules/Footer/index.test.js
+++ b/src/modules/Footer/index.test.js
@@ -77,4 +77,9 @@ describe('Footer', () => {
 
     expect(itemLink.props()).toHaveProperty('data-adobe-analytics', 'an-adobe-analytics-value');
   });
+
+  it('should add extra props passed to the component Footer', () => {
+    const component = shallow(<Footer faq={faq} items={items} copyright="copyright" answer="42" />);
+    expect(component.props()).toHaveProperty('answer', '42');
+  });
 });


### PR DESCRIPTION
Add props to the root footer element to be able to style it in our apps, as it is already done for the link component.