### PR TITLE
Fix import to resolve storybook build issue

### DIFF
--- a/src/elements/Logo/index.stories.js
+++ b/src/elements/Logo/index.stories.js
@@ -1,6 +1,6 @@
 import { withInfo } from '@storybook/addon-info';
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import Logo from '.';
+import { Logo } from '../..';
 
 storiesOf('Logo', module).add('default', withInfo()(() => <Logo />));

--- a/src/modules/Header/index.stories.js
+++ b/src/modules/Header/index.stories.js
@@ -1,6 +1,6 @@
 import { withInfo } from '@storybook/addon-info';
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import Header from '.';
+import { Header } from '../..';
 
 storiesOf('Header', module).add('default', withInfo()(() => <Header />));


### PR DESCRIPTION
The import `import Header from '.'` was not working on the build version of storybook, so I replace it with `import { Header } from '../..'`.

Same for the Logo component.

It's works now ;-)