### PR TITLE
IE11 card fixes

### DIFF
--- a/src/components/Card/ContentCard.js
+++ b/src/components/Card/ContentCard.js
@@ -6,11 +6,11 @@ import ChannelIcon from '../../elements/ChannelIcon';
 import PlayIcon from '../../elements/PlayIcon';
 import * as colors from '../../colors';
 
-const StyledImage = styled.img`
-  width: 100%;
+const StyledImage = styled.div`
   height: 180px;
-  object-fit: cover;
-  object-position: 50% 0;
+  background-image: ${({ src }) => `url(${src})`};
+  background-size: cover;
+  background-position: 50% 0;
   display: block;
 `;
 
@@ -59,7 +59,7 @@ const StyledContent = styled.div`
   padding: 16px 16px 8px;
   line-height: 1.3;
   background-color: ${colors.bunting};
-  flex: 1;
+  flex: 1 auto;
   display: flex;
   flex-direction: column;
 `;
@@ -75,7 +75,7 @@ const StyledCategory = styled.p`
 
 const footerBorder = rgba(colors.whiteLilac, 0.15);
 const StyledFooter = styled.div`
-  flex: 1;
+  flex: 1 auto;
   display: flex;
   align-items: flex-end;
   margin-top: 20px;
@@ -141,7 +141,7 @@ const ContentCard = ({ card, type, ...props }) => {
   return (
     <StyledCard {...props} href={url}>
       <StyledHeader>
-        <StyledImage src={img} alt={title} />
+        <StyledImage src={img} />
         {isPlayable && <StyledPlayIcon height={50} />}
         {isLive && <StyledLiveLabel>● {liveLabel}</StyledLiveLabel>}
       </StyledHeader>

--- a/src/components/Card/__snapshots__/ContentCard.test.js.snap
+++ b/src/components/Card/__snapshots__/ContentCard.test.js.snap
@@ -5,8 +5,7 @@ exports[`renders a Article ContentCard 1`] = `
   href="http://url.com"
 >
   <Styled(div)>
-    <Styled(img)
-      alt="Youth olympic summer games"
+    <Styled(div)
       src="https://i.eurosport.com/2018/10/29/2450727-50913270-2560-1440.jpg?w=200"
     />
   </Styled(div)>


### PR DESCRIPTION
Update flex shorthand for IE11 and use background-cover instead of object-fit

# Before

![image](https://user-images.githubusercontent.com/1711610/48426135-0f092600-e75e-11e8-85c5-aecd8944246e.png)

# After

![image](https://user-images.githubusercontent.com/1711610/48426144-16c8ca80-e75e-11e8-94ff-a1e4addf4e7d.png)
