### PR TITLE
Spread props passed to Header

### DIFF
--- a/src/modules/Header/index.js
+++ b/src/modules/Header/index.js
@@ -17,8 +17,8 @@ const StyledWrapper = styled.div`
   `)};
 `;
 
-const Header = () => (
-  <StyledWrapper>
+const Header = props => (
+  <StyledWrapper {...props}>
     <Logo />
   </StyledWrapper>
 );

--- a/src/modules/Header/index.test.js
+++ b/src/modules/Header/index.test.js
@@ -6,4 +6,10 @@ describe('Header', () => {
   it('renders Header', () => {
     expect(shallow(<Header />)).toMatchSnapshot();
   });
+
+  it('should accept other props', () => {
+    const component = shallow(<Header data-test-id="header" />);
+
+    expect(component.props()).toHaveProperty('data-test-id', 'header');
+  });
 });


### PR DESCRIPTION
This is to satisfy: https://github.com/EurosportDigital/web-toolkit/blob/master/CONTRIBUTING.md#requirements

> Components should spread props onto the top level component, for example: const Comp = ({...props}) => <div {...props} />, this should have a test