### PR TITLE
Add schedule card and extract Card Details component for reuse between Content card and Schedule card

### DIFF
--- a/src/components/Card/CardDetails.js
+++ b/src/components/Card/CardDetails.js
@@ -1,0 +1,106 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'react-emotion';
+import { rgba } from 'polished';
+import ChannelIcon from '../../elements/ChannelIcon';
+import * as colors from '../../colors';
+
+const StyledContent = styled.div`
+  padding: 16px 16px 8px;
+  line-height: 1.3;
+  flex: 1 auto;
+  display: flex;
+  flex-direction: column;
+`;
+
+const StyledCategory = styled.div`
+  font-size: 12px;
+  font-weight: bold;
+  text-transform: uppercase;
+  color: ${colors.turquoiseBlue};
+  letter-spacing: 1px;
+  margin: 0 0 10px;
+`;
+
+const footerBorder = rgba(colors.whiteLilac, 0.15);
+const StyledFooter = styled.div`
+  flex: 1 auto;
+  display: flex;
+  align-items: flex-end;
+  margin-top: 20px;
+  font-size: 14px;
+`;
+
+const StyledDetails = styled.div`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  border-top: 1px solid ${footerBorder};
+
+  * :nth-child(2) {
+    margin-left: 10px;
+    padding-left: 10px;
+    border-left: 1px solid ${footerBorder};
+    padding: 8px;
+  }
+`;
+
+const StyledTitle = styled.div`
+  font-size: 14px;
+  font-weight: bold;
+  color: ${colors.whiteLilac};
+  margin: 0 0 10px;
+`;
+
+const StyledDescription = styled.div`
+  color: ${colors.manatee};
+  font-size: 14px;
+  line-height: 20px;
+  margin: 0 0 10px;
+`;
+
+const StyledTimeStamp = styled.div`
+  padding: 8px 0;
+  margin: 0;
+  color: ${colors.manatee};
+  font-size: 12px;
+`;
+
+const CardDetails = ({ card, ...props }) => {
+  const { category, title, description, timestamp, channel } = card;
+  return (
+    <StyledContent {...props}>
+      <StyledCategory>{category}</StyledCategory>
+      <StyledTitle>{title}</StyledTitle>
+      {description && <StyledDescription>{description}</StyledDescription>}
+      <StyledFooter>
+        <StyledDetails>
+          {channel && <ChannelIcon height={15} type={channel} />}
+          <StyledTimeStamp>{timestamp}</StyledTimeStamp>
+        </StyledDetails>
+      </StyledFooter>
+    </StyledContent>
+  );
+};
+
+CardDetails.propTypes = {
+  card: PropTypes.shape({
+    category: PropTypes.string.isRequired,
+    title: PropTypes.string.isRequired,
+    description: PropTypes.string,
+    timestamp: PropTypes.string,
+    channel: PropTypes.string,
+  }),
+};
+
+CardDetails.defaultProps = {
+  card: {
+    description: null,
+    timestamp: null,
+    channel: null,
+  },
+};
+
+CardDetails.displayName = 'Cards.Content';
+
+export default CardDetails;

--- a/src/components/Card/CardDetails.js
+++ b/src/components/Card/CardDetails.js
@@ -90,15 +90,7 @@ CardDetails.propTypes = {
     description: PropTypes.string,
     timestamp: PropTypes.string,
     channel: PropTypes.string,
-  }),
-};
-
-CardDetails.defaultProps = {
-  card: {
-    description: null,
-    timestamp: null,
-    channel: null,
-  },
+  }).isRequired,
 };
 
 CardDetails.displayName = 'Cards.Content';

--- a/src/components/Card/CardDetails.test.js
+++ b/src/components/Card/CardDetails.test.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import CardDetails from './CardDetails';
+
+import ChannelIcon from '../../elements/ChannelIcon';
+
+const cardData = {
+  img: 'https://i.eurosport.com/2018/10/29/2450727-50913270-2560-1440.jpg?w=200',
+  url: '/article/1',
+  category: 'Tennis',
+  title: 'Youth olympic summer games',
+  timestamp: '09:00 - 10:30',
+  liveLabel: 'live label',
+};
+
+describe('CardDetails', () => {
+  it('Renders a carddetail component', () => {
+    const wrapper = shallow(<CardDetails card={cardData} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  describe('Channel icon', () => {
+    it('should not render an icon', () => {
+      const wrapper = shallow(<CardDetails card={cardData} />);
+      expect(wrapper.find(ChannelIcon)).toHaveLength(0);
+    });
+
+    it('should render an icon', () => {
+      const mockCardData = {
+        ...cardData,
+        channel: 'E1BR',
+      };
+      const wrapper = shallow(<CardDetails card={mockCardData} />);
+      expect(wrapper.find(ChannelIcon).prop('type')).toEqual('E1BR');
+    });
+  });
+
+  describe('Description', () => {
+    it('should not render a description', () => {
+      const wrapper = shallow(<CardDetails card={cardData} />);
+      expect(wrapper.html()).not.toContain('Description text');
+    });
+
+    it('should render a description', () => {
+      const mockCardData = {
+        ...cardData,
+        description: 'Description text',
+      };
+      const wrapper = shallow(<CardDetails card={mockCardData} />);
+      expect(wrapper.html()).toContain('Description text');
+    });
+  });
+});

--- a/src/components/Card/ContentCard.js
+++ b/src/components/Card/ContentCard.js
@@ -2,10 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'react-emotion';
 import { rgba } from 'polished';
-import ChannelIcon from '../../elements/ChannelIcon';
 import PlayIcon from '../../elements/PlayIcon';
 import * as colors from '../../colors';
 import Link from '../../elements/Link';
+import CardDetails from './CardDetails';
 
 const StyledImage = styled.div`
   height: 180px;
@@ -43,6 +43,7 @@ const StyledCard = styled(Link)`
   box-shadow: 0 1px 0 0 ${rgba(colors.mirage, 0.75)};
   text-decoration: none;
   overflow: hidden;
+  background-color: ${colors.bunting};
 
   &:hover {
     ${StyledHeader}:before {
@@ -53,61 +54,6 @@ const StyledCard = styled(Link)`
       border-color: ${colors.white};
     }
   }
-`;
-
-const StyledContent = styled.div`
-  padding: 16px 16px 8px;
-  line-height: 1.3;
-  background-color: ${colors.bunting};
-  flex: 1 auto;
-  display: flex;
-  flex-direction: column;
-`;
-
-const StyledCategory = styled.div`
-  font-size: 12px;
-  font-weight: bold;
-  text-transform: uppercase;
-  color: ${colors.turquoiseBlue};
-  letter-spacing: 1px;
-  margin: 0 0 10px;
-`;
-
-const footerBorder = rgba(colors.whiteLilac, 0.15);
-const StyledFooter = styled.div`
-  flex: 1 auto;
-  display: flex;
-  align-items: flex-end;
-  margin-top: 20px;
-  font-size: 14px;
-`;
-
-const StyledDetails = styled.div`
-  display: flex;
-  align-items: center;
-  width: 100%;
-  border-top: 1px solid ${footerBorder};
-
-  * :nth-child(2) {
-    margin-left: 10px;
-    padding-left: 10px;
-    border-left: 1px solid ${footerBorder};
-    padding: 8px;
-  }
-`;
-
-const StyledTitle = styled.div`
-  font-size: 14px;
-  font-weight: bold;
-  color: ${colors.whiteLilac};
-  margin: 0 0 10px;
-`;
-
-const StyledDescription = styled.div`
-  color: ${colors.manatee};
-  font-size: 14px;
-  line-height: 20px;
-  margin: 0 0 10px;
 `;
 
 export const StyledLiveLabel = styled.div`
@@ -126,17 +72,17 @@ export const StyledLiveLabel = styled.div`
   right: 10px;
 `;
 
-const StyledTimeStamp = styled.div`
-  padding: 8px 0;
-  margin: 0;
-  color: ${colors.manatee};
-  font-size: 12px;
-`;
-
 const ContentCard = ({ card, type, ...props }) => {
-  const { img, url, category, title, description, timestamp, channel, liveLabel } = card;
+  const { img, url, liveLabel } = card;
   const isLive = type === 'live';
   const isPlayable = isLive || type === 'vod';
+  const cardDetailsProps = {
+    category: card.category,
+    title: card.title,
+    description: card.description,
+    channel: card.channel,
+    timestamp: card.timestamp,
+  };
 
   return (
     <StyledCard {...props} href={url}>
@@ -145,17 +91,7 @@ const ContentCard = ({ card, type, ...props }) => {
         {isPlayable && <StyledPlayIcon height={50} />}
         {isLive && <StyledLiveLabel>● {liveLabel}</StyledLiveLabel>}
       </StyledHeader>
-      <StyledContent>
-        <StyledCategory>{category}</StyledCategory>
-        <StyledTitle>{title}</StyledTitle>
-        {description && <StyledDescription>{description}</StyledDescription>}
-        <StyledFooter>
-          <StyledDetails>
-            {isLive && <ChannelIcon height={15} type={channel} />}
-            <StyledTimeStamp>{timestamp}</StyledTimeStamp>
-          </StyledDetails>
-        </StyledFooter>
-      </StyledContent>
+      <CardDetails card={cardDetailsProps} />
     </StyledCard>
   );
 };

--- a/src/components/Card/ContentCard.js
+++ b/src/components/Card/ContentCard.js
@@ -73,16 +73,9 @@ export const StyledLiveLabel = styled.div`
 `;
 
 const ContentCard = ({ card, type, ...props }) => {
-  const { img, url, liveLabel } = card;
+  const { img, url, liveLabel, ...cardDetails } = card;
   const isLive = type === 'live';
   const isPlayable = isLive || type === 'vod';
-  const cardDetailsProps = {
-    category: card.category,
-    title: card.title,
-    description: card.description,
-    channel: card.channel,
-    timestamp: card.timestamp,
-  };
 
   return (
     <StyledCard {...props} href={url}>
@@ -91,7 +84,7 @@ const ContentCard = ({ card, type, ...props }) => {
         {isPlayable && <StyledPlayIcon height={50} />}
         {isLive && <StyledLiveLabel>● {liveLabel}</StyledLiveLabel>}
       </StyledHeader>
-      <CardDetails card={cardDetailsProps} />
+      <CardDetails card={cardDetails} />
     </StyledCard>
   );
 };

--- a/src/components/Card/ContentCard.test.js
+++ b/src/components/Card/ContentCard.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import ContentCard, { StyledPlayIcon, StyledLiveLabel } from './ContentCard';
-import ChannelIcon from '../../elements/ChannelIcon';
+import CardDetails from './CardDetails';
 
 const cardData = {
   img: 'https://i.eurosport.com/2018/10/29/2450727-50913270-2560-1440.jpg?w=200',
@@ -25,6 +25,19 @@ it('renders a ContentCard with play icon', () => {
   expect(wrapper.find(StyledPlayIcon).length).toEqual(1);
 });
 
+it('should pass correct props to CardDetails', () => {
+  const wrapper = shallow(<ContentCard card={cardData} type="live" />);
+  expect(wrapper.find(CardDetails).props()).toEqual({
+    card: {
+      category: cardData.category,
+      title: cardData.title,
+      description: cardData.description,
+      channel: cardData.channel,
+      timestamp: cardData.timestamp,
+    },
+  });
+});
+
 describe('Live Content Card', () => {
   it('renders a live label', () => {
     const wrapper = shallow(<ContentCard card={cardData} type="live" />);
@@ -39,10 +52,5 @@ describe('Live Content Card', () => {
   it('renders a play icon', () => {
     const wrapper = shallow(<ContentCard card={cardData} type="live" />);
     expect(wrapper.find(StyledPlayIcon).length).toEqual(1);
-  });
-
-  it('renders a channel logo', () => {
-    const wrapper = shallow(<ContentCard card={cardData} type="live" />);
-    expect(wrapper.find(ChannelIcon).prop('type')).toEqual('E1');
   });
 });

--- a/src/components/Card/ScheduleCard.js
+++ b/src/components/Card/ScheduleCard.js
@@ -1,0 +1,82 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled, { css } from 'react-emotion';
+import { rgba } from 'polished';
+import * as breakpoints from '../../breakpoints';
+import * as colors from '../../colors';
+
+import CardDetails from './CardDetails';
+
+const StyledWrapper = styled.div`
+  position: relative;
+  height: 169px;
+  display: flex;
+  border-radius: 2px;
+  overflow: hidden;
+  box-shadow: 0 2px 3px 0 ${rgba(colors.ebony, 0.3)};
+
+  ${breakpoints.small(css`
+    height: 149px;
+  `)};
+  ${breakpoints.large(css`
+    height: 160px;
+  `)};
+`;
+
+const StyledImage = styled.div`
+  background-image: ${({ img }) => `url(${img})`};
+  height: 100%;
+  width: 100%;
+  background-size: cover;
+  background-position: 50% 0;
+  display: block;
+  position: absolute;
+  opacity: 0.35;
+
+  :before {
+    content: '';
+    position: absolute;
+    z-index: 1;
+    height: 100%;
+    width: 101%;
+    background: linear-gradient(
+      180deg,
+      rgba(21, 23, 38, 0) 0%,
+      rgba(21, 23, 38, 0.3) 18.66%,
+      rgba(21, 23, 38, 0.85) 100%
+    );
+    opacity: 0.5;
+  }
+`;
+
+const StyledCardDetails = styled(CardDetails)`
+  padding: 20px 20px 10px;
+`;
+
+const ScheduleCard = ({ card, ...props }) => (
+  <StyledWrapper {...props}>
+    <StyledImage img={card.img} />
+    <StyledCardDetails card={card} />
+  </StyledWrapper>
+);
+
+ScheduleCard.propTypes = {
+  card: PropTypes.shape({
+    img: PropTypes.string.isRequired,
+    category: PropTypes.string.isRequired,
+    title: PropTypes.string.isRequired,
+    description: PropTypes.string,
+    timestamp: PropTypes.string,
+    channel: PropTypes.string,
+  }),
+};
+
+ScheduleCard.defaultProps = {
+  card: {
+    description: '',
+    timestamp: '',
+    channel: '',
+  },
+};
+
+export default ScheduleCard;

--- a/src/components/Card/ScheduleCard.js
+++ b/src/components/Card/ScheduleCard.js
@@ -68,15 +68,7 @@ ScheduleCard.propTypes = {
     description: PropTypes.string,
     timestamp: PropTypes.string,
     channel: PropTypes.string,
-  }),
-};
-
-ScheduleCard.defaultProps = {
-  card: {
-    description: '',
-    timestamp: '',
-    channel: '',
-  },
+  }).isRequired,
 };
 
 export default ScheduleCard;

--- a/src/components/Card/ScheduleCard.js
+++ b/src/components/Card/ScheduleCard.js
@@ -41,9 +41,9 @@ const StyledImage = styled.div`
     width: 101%;
     background: linear-gradient(
       180deg,
-      rgba(21, 23, 38, 0) 0%,
-      rgba(21, 23, 38, 0.3) 18.66%,
-      rgba(21, 23, 38, 0.85) 100%
+      transparent,
+      ${rgba(colors.mirage, 0.3)} 18.66%,
+      ${rgba(colors.mirage, 0.85)} 100%
     );
     opacity: 0.5;
   }

--- a/src/components/Card/ScheduleCard.test.js
+++ b/src/components/Card/ScheduleCard.test.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import ScheduleCard from './ScheduleCard';
+
+const mockCardData = {
+  img: 'https://i.eurosport.com/2018/10/29/2450727-50913270-2560-1440.jpg?w=200',
+  category: 'Tennis',
+  title: 'Youth olympic summer games',
+  description: 'Description',
+  timestamp: '09:00 - 10:30',
+  channel: 'E1',
+};
+
+describe('Schedule card', () => {
+  it('Renders a schedule card', () => {
+    const wrapper = shallow(<ScheduleCard card={mockCardData} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should add extra props passed to the component', () => {
+    const component = shallow(<ScheduleCard card={mockCardData} data-test="schedule-card" />);
+    expect(component.props()).toHaveProperty('data-test', 'schedule-card');
+  });
+});

--- a/src/components/Card/__snapshots__/CardDetails.test.js.snap
+++ b/src/components/Card/__snapshots__/CardDetails.test.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CardDetails Renders a carddetail component 1`] = `
+<Styled(div)>
+  <Styled(div)>
+    Tennis
+  </Styled(div)>
+  <Styled(div)>
+    Youth olympic summer games
+  </Styled(div)>
+  <Styled(div)>
+    <Styled(div)>
+      <Styled(div)>
+        09:00 - 10:30
+      </Styled(div)>
+    </Styled(div)>
+  </Styled(div)>
+</Styled(div)>
+`;

--- a/src/components/Card/__snapshots__/ContentCard.test.js.snap
+++ b/src/components/Card/__snapshots__/ContentCard.test.js.snap
@@ -10,23 +10,16 @@ exports[`renders a Article ContentCard 1`] = `
       src="https://i.eurosport.com/2018/10/29/2450727-50913270-2560-1440.jpg?w=200"
     />
   </Styled(div)>
-  <Styled(div)>
-    <Styled(div)>
-      Tennis
-    </Styled(div)>
-    <Styled(div)>
-      Youth olympic summer games
-    </Styled(div)>
-    <Styled(div)>
-      Description
-    </Styled(div)>
-    <Styled(div)>
-      <Styled(div)>
-        <Styled(div)>
-          09:00 - 10:30
-        </Styled(div)>
-      </Styled(div)>
-    </Styled(div)>
-  </Styled(div)>
+  <Cards.Content
+    card={
+      Object {
+        "category": "Tennis",
+        "channel": "E1",
+        "description": "Description",
+        "timestamp": "09:00 - 10:30",
+        "title": "Youth olympic summer games",
+      }
+    }
+  />
 </Styled(Link)>
 `;

--- a/src/components/Card/__snapshots__/ScheduleCard.test.js.snap
+++ b/src/components/Card/__snapshots__/ScheduleCard.test.js.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Schedule card Renders a schedule card 1`] = `
+<Styled(div)>
+  <Styled(div)
+    img="https://i.eurosport.com/2018/10/29/2450727-50913270-2560-1440.jpg?w=200"
+  />
+  <Styled(Cards.Content)
+    card={
+      Object {
+        "category": "Tennis",
+        "channel": "E1",
+        "description": "Description",
+        "img": "https://i.eurosport.com/2018/10/29/2450727-50913270-2560-1440.jpg?w=200",
+        "timestamp": "09:00 - 10:30",
+        "title": "Youth olympic summer games",
+      }
+    }
+  />
+</Styled(div)>
+`;

--- a/src/components/Card/index.js
+++ b/src/components/Card/index.js
@@ -1,3 +1,4 @@
 import Content from './ContentCard';
+import Schedule from './ScheduleCard';
 
-export default { Content };
+export default { Content, Schedule };

--- a/src/components/Card/index.stories.js
+++ b/src/components/Card/index.stories.js
@@ -11,22 +11,49 @@ const Wrapper = styled.div`
   max-width: 500px;
 `;
 
-const baseData = {
+const base = {
   img: 'https://i.eurosport.com/taiga/MagicBox/Crop/16_9/0_20180710-125830.jpeg?w=640',
   url: '/article/id',
   category: 'Tennis',
   title: 'Klopp happy with Chelsea draw after good performance',
   description: 'Day 2',
   timestamp: '09:00 - 10:30',
-  channel: 'E2NO',
-  liveLabel: 'live',
 };
 
-cardStories.add(
-  'Content Card',
-  withInfo({ propTablesExclude: [Wrapper] })(() => (
-    <Wrapper>
-      <Cards.Content card={object('card', baseData)} type={select('type', ['vod', 'article', 'live'], 'article')} />
-    </Wrapper>
-  ))
-);
+const data = {
+  vod: base,
+  live: {
+    ...base,
+    channel: 'E2NO',
+    liveLabel: 'live',
+  },
+  article: base,
+};
+
+const schedule = {
+  ...base,
+  channel: 'E1GB',
+};
+
+cardStories
+  .add(
+    'Content Card',
+    withInfo({ propTablesExclude: [Wrapper] })(() => {
+      const type = select('type', ['vod', 'article', 'live'], 'article');
+      const card = object('card', data[type]);
+
+      return (
+        <Wrapper>
+          <Cards.Content card={card} type={type} />
+        </Wrapper>
+      );
+    })
+  )
+  .add(
+    'Schedule Card',
+    withInfo({ propTablesExclude: [Wrapper] })(() => (
+      <Wrapper>
+        <Cards.Schedule card={object('card', schedule)} />
+      </Wrapper>
+    ))
+  );


### PR DESCRIPTION
As of this PR we now will show the channel icon if a channel is passed to either card, before this would only show if the card type was live. This will be a problem if you are passing the channel into the content card when you don't want the icon shown. So now it's the consumers responsibility to not pass that if it's not wanted.