### PR TITLE
Export hover styles so that the Card can control when they should be added, and prefer loading state to hover state

### DIFF
--- a/src/components/Card/ContentCard.js
+++ b/src/components/Card/ContentCard.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'react-emotion';
 import { rgba } from 'polished';
-import PlayIcon from '../../elements/PlayIcon';
+import PlayIcon, { hoverStyles as playIconHoverStyle } from '../../elements/PlayIcon';
 import * as colors from '../../colors';
 import Link from '../../elements/Link';
 import CardDetails from './CardDetails';
@@ -50,9 +50,7 @@ const StyledCard = styled(Link)`
       opacity: 0.1;
     }
 
-    ${StyledPlayIcon} {
-      border-color: ${colors.white};
-    }
+    ${playIconHoverStyle}
   }
 `;
 

--- a/src/elements/PlayIcon/__snapshots__/index.test.js.snap
+++ b/src/elements/PlayIcon/__snapshots__/index.test.js.snap
@@ -4,6 +4,7 @@ exports[`PlayIcon should render default icon 1`] = `
 <Styled(div)
   className="test"
   iconHeight={50}
+  withHoverState={false}
 >
   <Styled(div)
     isLoading={false}

--- a/src/elements/PlayIcon/__snapshots__/index.test.js.snap
+++ b/src/elements/PlayIcon/__snapshots__/index.test.js.snap
@@ -4,7 +4,6 @@ exports[`PlayIcon should render default icon 1`] = `
 <Styled(div)
   className="test"
   iconHeight={50}
-  withHoverState={false}
 >
   <Styled(div)
     isLoading={false}

--- a/src/elements/PlayIcon/__snapshots__/index.test.js.snap
+++ b/src/elements/PlayIcon/__snapshots__/index.test.js.snap
@@ -4,6 +4,7 @@ exports[`PlayIcon should render default icon 1`] = `
 <Styled(div)
   className="test"
   iconHeight={50}
+  isLoading={false}
 >
   <Styled(div)
     isLoading={false}

--- a/src/elements/PlayIcon/index.js
+++ b/src/elements/PlayIcon/index.js
@@ -47,7 +47,7 @@ const StyledWrapper = styled.div`
   overflow: hidden;
 
   :hover {
-    ${({ withHoverState }) => withHoverState && hoverStyles}
+    ${hoverStyles}
   }
 `;
 
@@ -62,7 +62,6 @@ PlayIcon.defaultProps = {
   alt: 'play',
   className: '',
   isLoading: false,
-  withHoverState: false,
 };
 
 PlayIcon.propTypes = {
@@ -70,7 +69,6 @@ PlayIcon.propTypes = {
   height: PropTypes.number.isRequired,
   className: PropTypes.string,
   isLoading: PropTypes.bool,
-  withHoverState: PropTypes.bool,
 };
 
 export default PlayIcon;

--- a/src/elements/PlayIcon/index.js
+++ b/src/elements/PlayIcon/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled, { keyframes } from 'react-emotion';
+import styled, { css, keyframes } from 'react-emotion';
 import { rgba } from 'polished';
 import { white, ebony } from '../../colors';
 import play from '../../assets/play.svg';
@@ -13,18 +13,6 @@ const spin = keyframes`
   100% {
     transform: rotate(360deg);
   }
-`;
-
-const StyledWrapper = styled.div`
-  position: relative;
-  display: inline-block;
-  height: ${({ iconHeight }) => `${iconHeight}px`};
-  width: ${({ iconHeight }) => `${iconHeight}px`};
-  padding: ${({ iconHeight }) => `${(iconHeight * 0.45) / 2}px`};
-  box-sizing: border-box;
-  border-radius: 50%;
-  background: ${rgba(ebony, 0.2)};
-  overflow: hidden;
 `;
 
 const StyledBorder = styled.div`
@@ -41,6 +29,28 @@ const StyledBorder = styled.div`
   animation: ${({ isLoading }) => isLoading && `${spin} 1s linear infinite`};
 `;
 
+export const hoverStyles = css`
+  ${StyledBorder} {
+    border-color: white;
+  }
+`;
+
+const StyledWrapper = styled.div`
+  position: relative;
+  display: inline-block;
+  height: ${({ iconHeight }) => `${iconHeight}px`};
+  width: ${({ iconHeight }) => `${iconHeight}px`};
+  padding: ${({ iconHeight }) => `${(iconHeight * 0.45) / 2}px`};
+  box-sizing: border-box;
+  border-radius: 50%;
+  background: ${rgba(ebony, 0.2)};
+  overflow: hidden;
+
+  :hover {
+    ${({ withHoverState }) => withHoverState && hoverStyles}
+  }
+`;
+
 const PlayIcon = ({ alt, height, isLoading, ...props }) => (
   <StyledWrapper {...props} iconHeight={height}>
     <StyledBorder isLoading={isLoading} />
@@ -52,6 +62,7 @@ PlayIcon.defaultProps = {
   alt: 'play',
   className: '',
   isLoading: false,
+  withHoverState: false,
 };
 
 PlayIcon.propTypes = {
@@ -59,6 +70,7 @@ PlayIcon.propTypes = {
   height: PropTypes.number.isRequired,
   className: PropTypes.string,
   isLoading: PropTypes.bool,
+  withHoverState: PropTypes.bool,
 };
 
 export default PlayIcon;

--- a/src/elements/PlayIcon/index.js
+++ b/src/elements/PlayIcon/index.js
@@ -47,12 +47,12 @@ const StyledWrapper = styled.div`
   overflow: hidden;
 
   :hover {
-    ${hoverStyles}
+    ${({ isLoading }) => !isLoading && hoverStyles}
   }
 `;
 
 const PlayIcon = ({ alt, height, isLoading, ...props }) => (
-  <StyledWrapper {...props} iconHeight={height}>
+  <StyledWrapper {...props} isLoading={isLoading} iconHeight={height}>
     <StyledBorder isLoading={isLoading} />
     <img src={play} alt={alt} />
   </StyledWrapper>

--- a/src/elements/PlayIcon/index.js
+++ b/src/elements/PlayIcon/index.js
@@ -31,7 +31,7 @@ const StyledBorder = styled.div`
 
 export const hoverStyles = css`
   ${StyledBorder} {
-    border-color: white;
+    border-color: ${white};
   }
 `;
 

--- a/src/elements/PlayIcon/index.stories.js
+++ b/src/elements/PlayIcon/index.stories.js
@@ -8,5 +8,11 @@ const iconsStories = storiesOf('PlayIcon', module);
 
 iconsStories.add(
   'configurable',
-  withInfo()(() => <PlayIcon height={number('Height', 50)} isLoading={boolean('isLoading', false)} />)
+  withInfo()(() => (
+    <PlayIcon
+      height={number('Height', 50)}
+      isLoading={boolean('isLoading', false)}
+      withHoverState={boolean('withHoverState', false)}
+    />
+  ))
 );


### PR DESCRIPTION
As of https://github.com/EurosportDigital/web-toolkit/pull/59 the hover state on the live Card play button is broken.

This fixes it by exporting the hover styles internally so that the Card no longer has to have knowledge of the `PlayIcon` internals to add a hover state meaning this shouldn't happen again.

I initially added a `withHoverState` prop, so that consumers could add the hover state if they wanted it, but I've removed it as I think it's safe to say that it should always be there. At least it does from our teams perspective.