### PR TITLE
EWL-823: update labels component to have simple mode.

### DIFF
--- a/src/elements/Labels/__snapshots__/index.test.js.snap
+++ b/src/elements/Labels/__snapshots__/index.test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Labels renders labels after event 1`] = `
-<Styled(div)>
+exports[`Labels when default mode renders labels after event 1`] = `
+<Styled(div)
+  isSimpleMode={false}
+>
   <Styled(div)
     bold={true}
     color="white"
@@ -27,8 +29,10 @@ exports[`Labels renders labels after event 1`] = `
 </Styled(div)>
 `;
 
-exports[`Labels renders labels before event 1`] = `
-<Styled(div)>
+exports[`Labels when default mode renders labels before event 1`] = `
+<Styled(div)
+  isSimpleMode={false}
+>
   <Styled(div)
     bold={true}
     color="white"
@@ -47,8 +51,10 @@ exports[`Labels renders labels before event 1`] = `
 </Styled(div)>
 `;
 
-exports[`Labels renders labels live event 1`] = `
-<Styled(div)>
+exports[`Labels when default mode renders labels live event 1`] = `
+<Styled(div)
+  isSimpleMode={false}
+>
   <Styled(div)
     bold={true}
     color="white"
@@ -73,6 +79,31 @@ exports[`Labels renders labels live event 1`] = `
       •
     </Styled(div)>
     Live
+  </Styled(div)>
+</Styled(div)>
+`;
+
+exports[`Labels when isSimpleMode renders labels in simple mode 1`] = `
+<Styled(div)
+  isSimpleMode={true}
+>
+  <Styled(div)
+    key="WORLD  CUPundefined"
+    layer={3}
+  >
+    WORLD  CUP
+  </Styled(div)>
+  <Styled(div)
+    key="LIGUE 1undefined"
+    layer={2}
+  >
+    LIGUE 1
+  </Styled(div)>
+  <Styled(div)
+    key="PARIS SAINT GERMANundefined"
+    layer={1}
+  >
+    PARIS SAINT GERMAN
   </Styled(div)>
 </Styled(div)>
 `;

--- a/src/elements/Labels/__snapshots__/index.test.js.snap
+++ b/src/elements/Labels/__snapshots__/index.test.js.snap
@@ -100,10 +100,10 @@ exports[`Labels when isSimpleMode renders labels in simple mode 1`] = `
     LIGUE 1
   </Styled(div)>
   <Styled(div)
-    key="PARIS SAINT GERMANundefined"
+    key="PARIS SAINT GERMAINundefined"
     layer={1}
   >
-    PARIS SAINT GERMAN
+    PARIS SAINT GERMAIN
   </Styled(div)>
 </Styled(div)>
 `;

--- a/src/elements/Labels/index.js
+++ b/src/elements/Labels/index.js
@@ -1,7 +1,15 @@
 import React from 'react';
 import styled, { css } from 'react-emotion';
 import PropTypes from 'prop-types';
-import { coreNeutral9, coreLightMinus1, royalBlue, utahCrimson, dodgerBlue, brandBase } from '../../colors';
+import {
+  coreNeutral9,
+  coreLightMinus1,
+  coreNeutral4,
+  royalBlue,
+  utahCrimson,
+  dodgerBlue,
+  brandBase,
+} from '../../colors';
 import { fontHelvetica } from '../../typography';
 import * as breakpoints from '../../breakpoints';
 
@@ -27,9 +35,46 @@ const colorsMapping = {
 const StyledLabels = styled.div`
   display: flex;
   flex-wrap: wrap;
+
+  ${props =>
+    props.isSimpleMode &&
+    css`
+      color: ${coreLightMinus1};
+      font-size: 8px;
+      line-height: 11px;
+      letter-spacing: 0.41px;
+    `}}
+
+  ${props =>
+    props.isSimpleMode &&
+    breakpoints.small(
+      css`
+        color: ${coreLightMinus1};
+        font-size: 11px;
+        line-height: 13px;
+        letter-spacing: 0.5px;
+      `
+    )}
 `;
 
-const StyledLabel = styled.div`
+export const StyledLabelSimple = styled.div`
+  font-weight: 300;
+
+  &::after {
+    display: inline-block;
+    content: '/';
+    margin: 0 0.5em;
+    color: ${coreNeutral4};
+  }
+
+  &:last-child {
+    &::after {
+      display: none;
+    }
+  }
+`;
+
+export const StyledLabel = styled.div`
   display: flex;
   ${fontHelvetica};
   font-size: 9.6px;
@@ -81,16 +126,25 @@ const StyledLabelIcon = styled.div`
   margin-right: 2px;
 `;
 
-const Labels = ({ labels }) => (
-  <StyledLabels>
-    {labels.map((label, index) => (
-      <StyledLabel color={label.color} bold={label.bold} key={label.text + label.color} layer={labels.length - index}>
-        {label.icon && <StyledLabelIcon>{label.icon}</StyledLabelIcon>}
-        {label.text}
-      </StyledLabel>
-    ))}
-  </StyledLabels>
-);
+const Labels = ({ labels, isSimpleMode }) => {
+  const LabelComponent = isSimpleMode ? StyledLabelSimple : StyledLabel;
+
+  return (
+    <StyledLabels isSimpleMode={isSimpleMode}>
+      {labels.map((label, index) => (
+        <LabelComponent
+          color={label.color}
+          bold={label.bold}
+          key={label.text + label.color}
+          layer={labels.length - index}
+        >
+          {label.icon && <StyledLabelIcon>{label.icon}</StyledLabelIcon>}
+          {label.text}
+        </LabelComponent>
+      ))}
+    </StyledLabels>
+  );
+};
 
 export const labelsType = PropTypes.arrayOf(
   PropTypes.shape({
@@ -101,8 +155,13 @@ export const labelsType = PropTypes.arrayOf(
   })
 );
 
+Labels.defaultProps = {
+  isSimpleMode: false,
+};
+
 Labels.propTypes = {
   labels: labelsType.isRequired,
+  isSimpleMode: PropTypes.bool,
 };
 
 export default Labels;

--- a/src/elements/Labels/index.js
+++ b/src/elements/Labels/index.js
@@ -58,6 +58,7 @@ const StyledLabels = styled.div`
 `;
 
 export const StyledLabelSimple = styled.div`
+  text-transform: uppercase;
   font-weight: 300;
 
   &::after {

--- a/src/elements/Labels/index.stories.js
+++ b/src/elements/Labels/index.stories.js
@@ -2,11 +2,12 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { object } from '@storybook/addon-knobs';
 import { Labels } from '../..';
-import { beforeEventLabels, liveEventLabels, afterEventLabels } from './mockData/labels';
+import { beforeEventLabels, liveEventLabels, afterEventLabels, simpleLabels } from './mockData/labels';
 
 const indexStories = storiesOf('Elements|Labels', module);
 
 indexStories
   .add('Before Event', () => <Labels labels={object('labels', beforeEventLabels)} />)
   .add('Live Event', () => <Labels labels={object('labels', liveEventLabels)} />)
-  .add('After Event', () => <Labels labels={object('labels', afterEventLabels)} />);
+  .add('After Event', () => <Labels labels={object('labels', afterEventLabels)} />)
+  .add('Simple mode', () => <Labels labels={object('labels', simpleLabels)} isSimpleMode />);

--- a/src/elements/Labels/index.test.js
+++ b/src/elements/Labels/index.test.js
@@ -1,19 +1,38 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import Labels from '.';
-import { beforeEventLabels, liveEventLabels, afterEventLabels } from './mockData/labels';
+import Labels, { StyledLabelSimple, StyledLabel } from '.';
+import { beforeEventLabels, liveEventLabels, afterEventLabels, simpleLabels } from './mockData/labels';
 
 describe('Labels', () => {
-  it('renders labels before event', () => {
-    const labels = shallow(<Labels labels={beforeEventLabels} />);
-    expect(labels).toMatchSnapshot();
+  describe('when isSimpleMode', () => {
+    it('renders <StyledLabelSimple /> component', () => {
+      const wrapper = shallow(<Labels labels={simpleLabels} isSimpleMode />);
+      expect(wrapper.find(StyledLabelSimple)).toHaveLength(simpleLabels.length);
+    });
+
+    it('renders labels in simple mode', () => {
+      const labels = shallow(<Labels labels={simpleLabels} isSimpleMode />);
+      expect(labels).toMatchSnapshot();
+    });
   });
-  it('renders labels live event', () => {
-    const labels = shallow(<Labels labels={liveEventLabels} />);
-    expect(labels).toMatchSnapshot();
-  });
-  it('renders labels after event', () => {
-    const labels = shallow(<Labels labels={afterEventLabels} />);
-    expect(labels).toMatchSnapshot();
+
+  describe('when default mode', () => {
+    it('renders <StyledLabel /> component', () => {
+      const wrapper = shallow(<Labels labels={simpleLabels} />);
+      expect(wrapper.find(StyledLabel)).toHaveLength(simpleLabels.length);
+    });
+
+    it('renders labels before event', () => {
+      const labels = shallow(<Labels labels={beforeEventLabels} />);
+      expect(labels).toMatchSnapshot();
+    });
+    it('renders labels live event', () => {
+      const labels = shallow(<Labels labels={liveEventLabels} />);
+      expect(labels).toMatchSnapshot();
+    });
+    it('renders labels after event', () => {
+      const labels = shallow(<Labels labels={afterEventLabels} />);
+      expect(labels).toMatchSnapshot();
+    });
   });
 });

--- a/src/elements/Labels/mockData/labels.json
+++ b/src/elements/Labels/mockData/labels.json
@@ -42,5 +42,17 @@
       "text": "Result",
       "color": "cyan"
     }
+  ],
+
+  "simpleLabels": [
+    {
+      "text": "WORLD  CUP"
+    },
+    {
+      "text": "LIGUE 1"
+    },
+    {
+      "text": "PARIS SAINT GERMAN"
+    }
   ]
 }

--- a/src/elements/Labels/mockData/labels.json
+++ b/src/elements/Labels/mockData/labels.json
@@ -52,7 +52,7 @@
       "text": "LIGUE 1"
     },
     {
-      "text": "PARIS SAINT GERMAN"
+      "text": "PARIS SAINT GERMAIN"
     }
   ]
 }

--- a/src/modules/MatchHero/__snapshots__/index.test.js.snap
+++ b/src/modules/MatchHero/__snapshots__/index.test.js.snap
@@ -5,6 +5,7 @@ exports[`<MatchHero /> should render as expected 1`] = `
   className="test"
 >
   <Labels
+    isSimpleMode={false}
     labels={
       Array [
         Object {
@@ -40,6 +41,7 @@ exports[`<MatchHeroWithScore />  should render as expected 1`] = `
   className="test"
 >
   <Labels
+    isSimpleMode={false}
     labels={
       Array [
         Object {


### PR DESCRIPTION
this updates `<Labels />` component to have `isSimpleMode` property.

then all labels are rendered like so:
<img width="292" alt="Screen Shot 2019-07-05 at 1 48 10 PM" src="https://user-images.githubusercontent.com/12991624/60717818-a3154100-9f2b-11e9-9c34-71959dff9fe3.png">

this tiny change would request then to implement simple label component usage directly in ETS.